### PR TITLE
visual: fix picking median image

### DIFF
--- a/visual.py
+++ b/visual.py
@@ -36,7 +36,7 @@ class Charts(object):
         match = self.metrics[has_image &
                              (np.abs(self.metrics['upload_size_mb'] -
                                      median) < 1)]['image']
-        if match.values:
+        if len(match.values) > 0:
             self.image = match.values[0]
         else:
             self.image = None


### PR DESCRIPTION
The traceback tells me to use any/all but I don't think that's what we really want.

Traceback (most recent call last):
  File "/home/fedora/devel/osbs-metrics/visual.py", line 184, in <module>
    Charts(sys.argv[1], sys.argv[2]).run()
  File "/home/fedora/devel/osbs-metrics/visual.py", line 39, in **init**
    if match.values:
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
