### PR TITLE
metrics: replace double quotes with single quotes

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -150,8 +150,8 @@ class Builds(object):
                 first_failed = sorted(errors.keys())[0]
                 plugins['failed_plugin'] = first_failed
                 exception_text = errors[first_failed].split("(")[0]
-                # Make sure quotes and commas are escaped
-                plugins['exception'] = json.dumps(exception_text)
+                # Make sure commas are escaped and double quotes are replaced
+                plugins['exception'] = json.dumps(exception_text.replace('"', "'"))
             except (KeyError, IndexError):
                 pass
 


### PR DESCRIPTION
It seems our CSV parser cannot handle escaped double quotes - bokeh metrics for 
OSD QA are broken. Since we don't need exact exception text (in fact we don't use 
it at all) its safe to replace double quotes with single quotes
