### PR TITLE
zabbix: send filesystem stats

### DIFF
--- a/zabbix_metrics_watcher.py
+++ b/zabbix_metrics_watcher.py
@@ -93,6 +93,14 @@ class Build(object):
             return {}
 
     @property
+    def filesystem(self):
+        try:
+            return json.loads(self._data['metadata']['annotations']['filesystem'])
+        except Exception as e:
+            logger.warn('Error filesystem: %r', e)
+            return {}
+
+    @property
     def created_time(self):
         try:
             timestamp = self._data['metadata']['creationTimestamp']
@@ -133,6 +141,8 @@ class Build(object):
             for k, v in self.durations.iteritems():
                 zabbix_result[k] = v
             zabbix_result['upload_size_mb'] = self.upload_size_mb
+            for fs_key, v in self.filesystem.items():
+                zabbix_result['fs_' + fs_key] = v
             try:
                 if 'pulp_push' in zabbix_result.keys():
                     zabbix_result['pulp_push_speed'] =\


### PR DESCRIPTION
ref OSBS-3053
Builds that have completed should be annotated with filesystem metrics.
Expect the following new values in zabbix notification:

    fs_mb_free fs_mb_total fs_mb_used
    fs_inodes_free fs_inodes_total fs_inodes_used